### PR TITLE
Build fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 
 plugindir = $(libdir)/gio/modules
-plugin_cflags =	-Isrc -std=gnu99 -Wall -O2 -D_FORTIFY_SOURCE=2 \
+plugin_cflags =	-Isrc -std=gnu99 \
 	@DBUS_CFLAGS@ @GLIB_CFLAGS@ @GOBJECT_CFLAGS@ \
 	@GIO_CFLAGS@ @CONCFLAGS@
 plugin_ldflags = -no-undefined -module -avoid-version $(DBUS_LIBS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,7 @@ plugindir = $(libdir)/gio/modules
 plugin_cflags =	-Isrc -std=gnu99 \
 	@DBUS_CFLAGS@ @GLIB_CFLAGS@ @GOBJECT_CFLAGS@ \
 	@GIO_CFLAGS@ @CONCFLAGS@
-plugin_ldflags = -no-undefined -module -avoid-version $(DBUS_LIBS)
+plugin_ldflags = -no-undefined -module -avoid-version
 
 connman_sources = src/connman-api.c src/connman-api.h
 
@@ -16,7 +16,7 @@ endif # MAINTAINER_MODE
 plugin_LTLIBRARIES = libconnman-network-monitor.la
 plugin_objects = $(libconnman_network_monitor_la_OBJECTS)
 libconnman_network_monitor_la_CFLAGS = $(plugin_cflags)
-libconnman_network_monitor_la_LIBADD = $(DBUS_LIBS) $(DBUS_GLIB_LIBS)
+libconnman_network_monitor_la_LIBADD = $(DBUS_LIBS) $(GLIB_LIBS) $(GOBJECT_LIBS) $(GIO_LIBS)
 libconnman_network_monitor_la_SOURCES = src/connman-network-monitor.c \
 					$(connman_sources)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -37,3 +37,14 @@ MAINTAINERCLEANFILES = \
         install-sh ltmain.sh missing mkinstalldirs \
         config.log config.status config.guess config.sub \
         build-stamp compile depcomp acinclude.m4 aclocal.m4
+
+# Need to rebuild the GIO module cache on install and uninstall
+install-exec-hook:
+	if test -n "$(GIO_QUERYMODULES)" -a -z "$(DESTDIR)"; then \
+		$(GIO_QUERYMODULES) $(GIO_MODULE_DIR); \
+	fi
+
+uninstall-hook:
+	if test -n "$(GIO_QUERYMODULES)" -a -z "$(DESTDIR)"; then \
+		$(GIO_QUERYMODULES) $(GIO_MODULE_DIR); \
+	fi

--- a/configure.ac
+++ b/configure.ac
@@ -51,6 +51,9 @@ else
 fi
 AC_SUBST(GIO_MODULE_DIR)
 
+AC_PATH_PROG([GIO_QUERYMODULES],[gio-querymodules])
+AC_SUBST([GIO_QUERYMODULES])
+
 AC_ARG_ENABLE([test],
 		[AS_HELP_STRING([--enable-test], [Enable test programs])],
 		[],[enable_test=no])

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ(2.60)
 AC_INIT(libconnman-network-monitor, 0.1)
-AM_INIT_AUTOMAKE(AC_PACKAGE_NAME, AC_PACKAGE_VERSION)
+AM_INIT_AUTOMAKE([subdir-objects])
 
 AM_CONFIG_HEADER(config.h)
 

--- a/src/connman-network-monitor.c
+++ b/src/connman-network-monitor.c
@@ -34,6 +34,7 @@ static guint network_changed_signal = 0;
 enum {
 	PROP_0,
 	PROP_NETWORK_AVAILABLE,
+	PROP_CONNECTIVITY,
 };
 
 enum connman_state {
@@ -149,6 +150,11 @@ static void get_property(GObject *object, guint prop_id,
 		g_value_set_boolean(value, get_state(monitor));
 		break;
 
+	case PROP_CONNECTIVITY:
+		/* FIXME: Implement connectivity and captive portal checking. */
+		g_value_set_enum(value, get_state(monitor) ? G_NETWORK_CONNECTIVITY_FULL : G_NETWORK_CONNECTIVITY_LOCAL);
+		break;
+
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
 		break;
@@ -168,6 +174,9 @@ g_network_monitor_connman_class_init(GNetworkMonitorConnmanClass *klass)
 	g_object_class_override_property(gobject_class,
 					PROP_NETWORK_AVAILABLE,
 					"network-available");
+	g_object_class_override_property(gobject_class,
+					PROP_CONNECTIVITY,
+					"connectivity");
 
 	g_type_class_add_private(gobject_class,
 				sizeof(GNetworkMonitorConnmanPrivate));

--- a/src/connman-network-monitor.c
+++ b/src/connman-network-monitor.c
@@ -329,7 +329,7 @@ void g_io_module_unload(GIOModule *module)
 
 char** g_io_module_query(void)
 {
-	char **eps = g_try_new(char *, 2);
+	char **eps = g_new(char *, 2);
 	eps[0] = g_strdup(G_NETWORK_MONITOR_EXTENSION_POINT_NAME);
 	eps[1] = NULL;
 	return eps;


### PR DESCRIPTION
Various build fixes to get `GNetworkMonitorConnman` vaguely up to date with GLib 2.44. Not thoroughly tested.
